### PR TITLE
Implement LowRank state with ghost memory

### DIFF
--- a/vega7/model.py
+++ b/vega7/model.py
@@ -3,6 +3,80 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
+class LowRankStateMixing(nn.Module):
+    """Matrix-valued state with active and ghost blocks."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        heads: int = 4,
+        rank: int = 1,
+        ghost_dtype: torch.dtype = torch.float16,
+    ) -> None:
+        super().__init__()
+        if hidden_size % heads != 0:
+            raise ValueError("hidden_size must be divisible by heads")
+        self.hidden_size = hidden_size
+        self.heads = heads
+        self.head_dim = hidden_size // heads
+        self.rank = rank
+        self.ghost_dtype = ghost_dtype
+
+        # Parameter generator for rank-1 update
+        self.param_generator = nn.Linear(hidden_size, heads + self.head_dim)
+        self.ghost_update_gate = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.ghost_update_transform = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.receptance = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.output = nn.Linear(hidden_size, hidden_size, bias=False)
+        self.ln_x = nn.LayerNorm(hidden_size)
+
+    def init_state(self, batch_size: int, device: torch.device):
+        active = torch.zeros(batch_size, self.heads, self.head_dim, device=device)
+        ghost = torch.zeros(
+            batch_size,
+            self.heads,
+            self.head_dim,
+            device=device,
+            dtype=self.ghost_dtype,
+        )
+        return active, ghost
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        state: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ):
+        B, T, _ = x.size()
+        x = self.ln_x(x)
+        r = self.receptance(x)
+        if state is None:
+            active, ghost = self.init_state(B, x.device)
+        else:
+            active, ghost = state
+
+        outputs = []
+        for t in range(T):
+            xt = x[:, t]
+            params = self.param_generator(xt)
+            u, v = params.split([self.heads, self.head_dim], dim=-1)
+            active = active + u.unsqueeze(-1) * v.unsqueeze(1)
+
+            gate = torch.sigmoid(self.ghost_update_gate(xt)).view(B, self.heads, self.head_dim)
+            transform = torch.tanh(self.ghost_update_transform(xt)).view(
+                B, self.heads, self.head_dim
+            )
+            ghost = ghost + (gate * transform).to(self.ghost_dtype)
+
+            combined = active + ghost.to(dtype=active.dtype)
+            rt = r[:, t].view(B, self.heads, self.head_dim).sigmoid()
+            out = torch.einsum("bhd,bhd->bd", rt, combined)
+            outputs.append(out)
+
+        output = torch.stack(outputs, dim=1)
+        output = self.output(output)
+        return output, (active, ghost)
+
+
 class RWKV7TimeMixing(nn.Module):
     """Time mixing module replacing self-attention"""
 
@@ -81,10 +155,20 @@ class Vega7Model(nn.Module):
 
         self.layers = nn.ModuleList()
         for i in range(config["n_layers"]):
+            if "state_heads" in config:
+                time_mixing = LowRankStateMixing(
+                    config["hidden_size"],
+                    heads=config["state_heads"],
+                    rank=1,
+                )
+            else:
+                time_mixing = RWKV7TimeMixing(
+                    config["hidden_size"], config["n_layers"], i
+                )
             self.layers.append(
                 nn.ModuleDict(
                     {
-                        "time_mixing": RWKV7TimeMixing(config["hidden_size"], config["n_layers"], i),
+                        "time_mixing": time_mixing,
                         "channel_mixing": ChannelMixing(
                             config["hidden_size"],
                             i,
@@ -97,7 +181,9 @@ class Vega7Model(nn.Module):
         self.ln_out = nn.LayerNorm(config["hidden_size"])
         self.head = nn.Linear(config["hidden_size"], config["vocab_size"], bias=False)
 
-    def forward(self, input_ids: torch.Tensor, states: list[torch.Tensor] | None = None):
+    def forward(
+        self, input_ids: torch.Tensor, states: list | None = None
+    ):
         x = self.embeddings(input_ids)
         if states is None:
             states = [None] * len(self.layers)

--- a/vega7/training.py
+++ b/vega7/training.py
@@ -56,7 +56,8 @@ def load_teacher_model(model_name: str = "Qwen/Qwen2.5-0.5B"):
 
 def get_config() -> Dict:
     return {
-        "hidden_size": 512,
+        "state_heads": 4,
+        "hidden_size": 256 * 4,
         "n_layers": 8,
         "ffn_size": 2048,
         "batch_size": 2,


### PR DESCRIPTION
## Summary
- implement `LowRankStateMixing` to maintain a matrix‐valued state with an active and a fp16 ghost block
- allow `Vega7Model` layers to use this mixing module when `state_heads` is configured
- configure training to use four 256‑d heads

## Testing
- `pip install torch==2.0.1 --extra-index-url https://download.pytorch.org/whl/cpu` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685f76ee80688323aef2de6a1435b067