### PR TITLE
Add accelerate dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Install the required dependencies:
 pip install -r requirements.txt
 ```
 
+The training script loads the teacher model with 8-bit weights using
+`device_map="auto"`, so the [Hugging Face Accelerate](https://github.com/huggingface/accelerate)
+library is required.
+
 Run a small distillation demo:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license = {text = "Apache-2.0"}
 dependencies = [
     "torch>=2.0",
     "transformers>=4.0",
+    "accelerate>=0.20",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch
 transformers
+accelerate
 


### PR DESCRIPTION
## Summary
- document that `accelerate` is required for loading 8‑bit models
- add `accelerate` to requirements and project dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685f7ad9e2f0832390c1c6e759934abd