### PR TITLE
Fix dimension mismatch in LowRankStateMixing

### DIFF
--- a/vega7/model.py
+++ b/vega7/model.py
@@ -69,7 +69,9 @@ class LowRankStateMixing(nn.Module):
 
             combined = active + ghost.to(dtype=active.dtype)
             rt = r[:, t].view(B, self.heads, self.head_dim).sigmoid()
-            out = torch.einsum("bhd,bhd->bd", rt, combined)
+            # Preserve the full hidden dimension by elementwise
+            # multiplying per head and then flattening
+            out = (rt * combined).reshape(B, -1)
             outputs.append(out)
 
         output = torch.stack(outputs, dim=1)


### PR DESCRIPTION
## Summary
- fix shape mismatch in LowRankStateMixing forward

## Testing
- `pip install torch --quiet` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_685f805f169c83238d8156009aa2cc23